### PR TITLE
Fixes callbackContext.failure cannot find symbol error

### DIFF
--- a/src/android/FFMpeg.java
+++ b/src/android/FFMpeg.java
@@ -15,7 +15,7 @@ public class FFMpeg extends CordovaPlugin {
             if (returnCode == RETURN_CODE_SUCCESS)
                 callbackContext.success("Done");
             else
-                callbackContext.failure("Error Code: " + returnCode);
+                callbackContext.error("Error Code: " + returnCode);
             return true;
         } else return false;
     }


### PR DESCRIPTION
Throws error on build 

So i changed callbackContext.failure to callbackContext.error as it is on the  [CallBackContext class](https://github.com/apache/cordova-android/blob/master/framework/src/org/apache/cordova/CallbackContext.java)
i dont understand why those errors didnt pop up for you as it has always been like this.
maybe a different gradle version
Related issue: #4