### PR TITLE
Execute ffmpeg commands asynchronously

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -45,7 +45,7 @@
           <source url="https://github.com/CocoaPods/Specs.git"/>
       </config>
       <pods use-frameworks="true">
-          <pod name="mobile-ffmpeg-full-gpl" spec="~> 4.3.1" />
+          <pod name="mobile-ffmpeg-full-gpl" spec="~> 4.4" />
       </pods>
     </podspec>
   </platform>

--- a/src/android/FFMpeg.java
+++ b/src/android/FFMpeg.java
@@ -3,6 +3,7 @@ package com.marin.plugin;
 import org.apache.cordova.*;
 import org.json.JSONArray;
 import org.json.JSONException;
+import com.arthenica.mobileffmpeg.ExecuteCallback;
 import com.arthenica.mobileffmpeg.FFmpeg;
 import static com.arthenica.mobileffmpeg.Config.RETURN_CODE_SUCCESS;
  // ref: https://github.com/tanersener/mobile-ffmpeg/wiki/Android
@@ -11,11 +12,15 @@ public class FFMpeg extends CordovaPlugin {
     @Override
     public boolean execute(String action, JSONArray data, CallbackContext callbackContext) throws JSONException {
         if (action.equals("exec")) {
-            int returnCode = FFmpeg.execute(data.getString(0));
-            if (returnCode == RETURN_CODE_SUCCESS)
-                callbackContext.success("Done");
-            else
-                callbackContext.error("Error Code: " + returnCode);
+            FFmpeg.executeAsync(data.getString(0), new ExecuteCallback() {
+                @Override
+                public void apply(long executionId, int returnCode) {
+                    if (returnCode == RETURN_CODE_SUCCESS)
+                        callbackContext.success("Done");
+                    else
+                        callbackContext.error("Error Code: " + returnCode);
+                }
+            });
             return true;
         } else return false;
     }

--- a/src/android/FFMpeg.java
+++ b/src/android/FFMpeg.java
@@ -15,7 +15,7 @@ public class FFMpeg extends CordovaPlugin {
             if (returnCode == RETURN_CODE_SUCCESS)
                 callbackContext.success("Done");
             else
-                callbackContext.failure("Error Code: " + returnCode);
+                callbackContext.error("Error Code: " + returnCode);
             return true;
         } else return false;
     }

--- a/src/ios/HWPFFMpeg.h
+++ b/src/ios/HWPFFMpeg.h
@@ -1,6 +1,7 @@
 #import <Cordova/CDV.h>
+#import <mobileffmpeg/MobileFFmpeg.h>
 
-@interface HWPFFMpeg : CDVPlugin
+@interface HWPFFMpeg : CDVPlugin<ExecuteDelegate>
 
 - (void) exec:(CDVInvokedUrlCommand*)command;
 


### PR DESCRIPTION
Current implementation executes ffmpeg commands synchronously which freezes up the cordova view.

Have switched over to asynchronous so ffmpeg can run in the background.

Also includes @rhiroshi 's  fix from https://github.com/adminy/cordova-plugin-ffmpeg/pull/5