### PR TITLE
Add command output to Android result

### DIFF
--- a/src/android/FFMpeg.java
+++ b/src/android/FFMpeg.java
@@ -14,9 +14,10 @@ public class FFMpeg extends CordovaPlugin {
         if (action.equals("exec")) {
             FFmpeg.executeAsync(data.getString(0), new ExecuteCallback() {
                 @Override
+                String result = String.format("Done out=%s", Config.getLastCommandOutput());
                 public void apply(long executionId, int returnCode) {
                     if (returnCode == RETURN_CODE_SUCCESS)
-                        callbackContext.success("Done");
+                        callbackContext.success(result);
                     else
                         callbackContext.error("Error Code: " + returnCode);
                 }

--- a/src/android/FFMpeg.java
+++ b/src/android/FFMpeg.java
@@ -5,6 +5,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import com.arthenica.mobileffmpeg.ExecuteCallback;
 import com.arthenica.mobileffmpeg.FFmpeg;
+import com.arthenica.mobileffmpeg.Config;
 import static com.arthenica.mobileffmpeg.Config.RETURN_CODE_SUCCESS;
  // ref: https://github.com/tanersener/mobile-ffmpeg/wiki/Android
 public class FFMpeg extends CordovaPlugin {

--- a/src/android/FFMpeg.java
+++ b/src/android/FFMpeg.java
@@ -14,8 +14,8 @@ public class FFMpeg extends CordovaPlugin {
         if (action.equals("exec")) {
             FFmpeg.executeAsync(data.getString(0), new ExecuteCallback() {
                 @Override
-                String result = String.format("Done out=%s", Config.getLastCommandOutput());
                 public void apply(long executionId, int returnCode) {
+                    String result = String.format("Done out=%s", Config.getLastCommandOutput());
                     if (returnCode == RETURN_CODE_SUCCESS)
                         callbackContext.success(result);
                     else


### PR DESCRIPTION
The iOS side of the plugin [returns the last command output to JavaScript](https://github.com/adminy/cordova-plugin-ffmpeg/blob/master/src/ios/HWPFFMpeg.m#L25-L27)

This PR adds the same functionality to the Android side, returning the last command output instead of just "Done"