### PR TITLE
Add support for running probe on a video to get media information

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,28 +9,54 @@ Create a new Cordova Project
     $ cordova create hello com.example.helloapp Hello
 
 make sure you have cocoapods **On MacOS**
->`sudo gem install cocoapods`
 
+> `sudo gem install cocoapods`
 
 Install the plugin
 
     $ cd hello
     $ cordova plugin add https://github.com/adminy/cordova-plugin-ffmpeg.git
-    
 
 Edit `www/js/index.js` and add the following code inside `onDeviceReady`
 
 ```js
-    ffmpeg.exec("-i someinput.mp4 -vn -c:a copy out.mp3", success => alert(success), failure => alert(failure));
+ffmpeg.exec("-i someinput.mp4 -vn -c:a copy out.mp3", (success) => alert(success), (failure) => alert(failure));
 ```
 
 Make sure you have the files that will be required by ffmpeg
+
+You can also run the `FFProbe` command to get video information:
+
+```js
+ffmpeg.probe(
+  "somefile.mp4",
+  (result) => {
+    console.log("Video details:");
+    console.log(result.format.bit_rate);
+    console.log(result.format.duration);
+    console.log(result.format.filename);
+    console.log(result.format.format_name);
+    console.log(result.format.nb_programs);
+    console.log(result.format.nb_streams);
+    console.log(result.format.probe_score);
+    console.log(result.format.size);
+    console.log(result.format.start_time);
+
+    // You also get details about the video/audio streams of the file
+    console.log(result.streams[0].codec_name); // e.g. h264
+    console.log(result.streams[0].codec_type); // e.g. 'video'
+    console.log(result.streams[1].codec_name); // e.g. aac
+    console.log(result.streams[1].codec_type); // e.g. 'audio'
+  },
+  (error) => alert(error)
+);
+```
 
 Install iOS or Android platform
 
     cordova platform add ios
     cordova platform add android
-    
+
 Run the code
 
     cordova run

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-ffmpeg",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Cordova FFMPEG plugin with mobile-ffmpeg",
   "cordova": {
     "id": "cordova-plugin-ffmpeg",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="com.marin.ffmpeg"
-        version="1.0.1">
+        version="1.1.0">
 
   <name>FFMpeg</name>
 

--- a/src/android/FFMpeg.java
+++ b/src/android/FFMpeg.java
@@ -3,9 +3,14 @@ package com.marin.plugin;
 import org.apache.cordova.*;
 import org.json.JSONArray;
 import org.json.JSONException;
+import com.arthenica.mobileffmpeg.Config;
 import com.arthenica.mobileffmpeg.ExecuteCallback;
 import com.arthenica.mobileffmpeg.FFmpeg;
-import com.arthenica.mobileffmpeg.Config;
+import com.arthenica.mobileffmpeg.FFprobe;
+import com.arthenica.mobileffmpeg.MediaInformation;
+import com.arthenica.mobileffmpeg.Statistics;
+import com.arthenica.mobileffmpeg.StatisticsCallback;
+
 import static com.arthenica.mobileffmpeg.Config.RETURN_CODE_SUCCESS;
  // ref: https://github.com/tanersener/mobile-ffmpeg/wiki/Android
 public class FFMpeg extends CordovaPlugin {
@@ -23,6 +28,15 @@ public class FFMpeg extends CordovaPlugin {
                         callbackContext.error("Error Code: " + returnCode);
                 }
             });
+            return true;
+        } else if(action.equals("probe")) {
+            MediaInformation info = FFprobe.getMediaInformation(data.getString(0));
+            int returnCode = Config.getLastReturnCode();
+            if(returnCode == RETURN_CODE_SUCCESS) {
+                callbackContext.success(info.getAllProperties());
+            } else {
+                callbackContext.error(Config.getLastCommandOutput());
+            }
             return true;
         } else return false;
     }

--- a/src/ios/HWPFFMpeg.h
+++ b/src/ios/HWPFFMpeg.h
@@ -4,5 +4,6 @@
 @interface HWPFFMpeg : CDVPlugin<ExecuteDelegate>
 
 - (void) exec:(CDVInvokedUrlCommand*)command;
+- (void) probe:(CDVInvokedUrlCommand*)command;
 
 @end

--- a/src/ios/HWPFFMpeg.m
+++ b/src/ios/HWPFFMpeg.m
@@ -20,6 +20,25 @@ NSMutableDictionary *mappings;
 
 }
 
+- (void)probe:(CDVInvokedUrlCommand*)command {
+    NSString* filePath = [[command arguments] objectAtIndex:0];
+    MediaInformation *mediaInformation = [MobileFFprobe getMediaInformation:filePath];
+    int returnCode = [MobileFFmpegConfig getLastReturnCode];
+
+    if(returnCode == RETURN_CODE_SUCCESS) {
+        CDVPluginResult* result = [CDVPluginResult
+                               resultWithStatus:CDVCommandStatus_OK
+                               messageAsDictionary:[mediaInformation getAllProperties]];
+        [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
+    } else {
+        CDVPluginResult* result = [CDVPluginResult
+                                   resultWithStatus:CDVCommandStatus_ERROR
+                                   messageAsString:[MobileFFmpegConfig getLastCommandOutput]];
+        [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
+    }
+}
+
+
 - (void)executeCallback:(long)executionId :(int)returnCode {
     NSString* responseToUser;
     NSString *output = [MobileFFmpegConfig getLastCommandOutput];

--- a/www/ffmpeg.js
+++ b/www/ffmpeg.js
@@ -1,7 +1,10 @@
 /*global cordova, module*/
 
 module.exports = {
-    exec: function (cmd, successCallback, errorCallback) {
-        cordova.exec(successCallback, errorCallback, "FFMpeg", "exec", [cmd]);
-    }
+  exec: function (cmd, successCallback, errorCallback) {
+    cordova.exec(successCallback, errorCallback, "FFMpeg", "exec", [cmd]);
+  },
+  probe: function (filePath, statusCallback, errorCallback) {
+    cordova.exec(statusCallback, errorCallback, "FFMpeg", "probe", [filePath]);
+  },
 };


### PR DESCRIPTION
Tested on both iOS and Android.

Example usage:

```
ffmpeg.probe(
  "path/to/somefile.mp4",
  (result) => {
    console.log("Video details:");
    console.log(result.format.bit_rate);
    console.log(result.format.duration);
    console.log(result.format.filename);
    console.log(result.format.format_name);
    console.log(result.format.nb_programs);
    console.log(result.format.nb_streams);
    console.log(result.format.probe_score);
    console.log(result.format.size);
    console.log(result.format.start_time);

    // You also get details about the video/audio streams of the file
    console.log(result.streams[0].codec_name); // e.g. h264
    console.log(result.streams[0].codec_type); // e.g. 'video'
    console.log(result.streams[1].codec_name); // e.g. aac
    console.log(result.streams[1].codec_type); // e.g. 'audio'
  },
  (error) => alert(error)
);
```